### PR TITLE
Updated [os.symbols] with the pop_os nerdfont

### DIFF
--- a/starship.toml
+++ b/starship.toml
@@ -64,6 +64,7 @@ CentOS = ""
 Debian = "󰣚"
 Redhat = "󱄛"
 RedHatEnterprise = "󱄛"
+Pop = ""
 
 [username]
 show_always = true


### PR DESCRIPTION
Included the Pop!_OS nerdfont symbol for the Gruvbox-rainbow preset under [os.symbols]

I'm currently using a system76 laptop with Pop!_OS running on it. 
I was testing out your gruvbox rainbow preset and noticed the os symbol was a lollipop and thought including the Pop!_OS nerdfont symbol would be enjoyed by other Pop!_OS users.

I run starship on the GNOME Terminal, within Pop!_OS using the Gruvbox Rainbow Preset.